### PR TITLE
feat(cli-summon): add option to specify boolify width

### DIFF
--- a/packages/cli-summon/src/index.ts
+++ b/packages/cli-summon/src/index.ts
@@ -16,9 +16,10 @@ program
     .name("mpc-cli-summonc")
     .description(description)
     .version(version, "-v, --version", "Show MPC-create-app version.")
+    .option("--boolify-width <width>", "Produce boolean circuits with a specific width.")
     .argument("<circuit-file>", "Circuit file to compile.")
     .allowExcessArguments(false)
-    .action(async (circuitFilePath) => {
+    .action(async (circuitFilePath, { boolifyWidth }) => {
         if (!existsSync(circuitFilePath)) {
             console.info(`\n ${logSymbols.error}`, `error: the '${circuitFilePath}' file does not exist\n`)
             return
@@ -32,7 +33,10 @@ program
 
         await summon.init()
 
-        const circuit = summon.compile(circuitFilePath, (filePath) => readFileSync(filePath, "utf8"))
+        const fileReader = (filePath: string) => readFileSync(filePath, "utf8")
+        const circuit = boolifyWidth
+            ? summon.compileBoolean(circuitFilePath, boolifyWidth, fileReader)
+            : summon.compile(circuitFilePath, fileReader)
 
         spinner.stop()
 


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

This PR adds an option to the Summon CLI to specify a [Boolify](https://github.com/voltrevo/boolify) width (`--boolify-width <width>`), like the [Rust CLI](https://github.com/voltrevo/summon).

The code has been tested with a local version of `summon-ts`, based on https://github.com/voltrevo/summon-ts/pull/6. The dependency in this PR will be updated as soon as a new version of `summon-ts` is released.

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `yarn format` and `yarn lint` without getting any errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
